### PR TITLE
Integrate /migrate-machine endpoint with executor

### DIFF
--- a/pkg/api/migrate_machine.go
+++ b/pkg/api/migrate_machine.go
@@ -2,41 +2,88 @@ package api
 
 import (
 	"encoding/json"
+	"log"
 	"net/http"
+	"strings"
+
+	"github.com/leapp-to/leapp-go/pkg/executor"
 )
 
+// RUNNER is an actor execution tool
+// TODO: using a wrapper script for testing only, but runner.py in snactor repo should be refactored into a standalone tool so it can be used by leapp-daemon
+const RUNNER = "/home/fjb/src/snactor/runner_wrapper.sh"
+
+// MigrateParams represents the parameters sent by the client
+// TODO: there are more parameters to add here
 type MigrateParams struct {
-	SourceHost       string            `json:"source_host,omitempty"`
-	TargetHost       string            `json:"target_host,omitempty"`
-	ContainerName    string            `json:"container_name,omitempty"`
-	SourceUser       string            `json:"source_user,omitempty"`
-	TargetUser       string            `json:"target_user,omitempty"`
-	ExcludePaths     []string          `json:"excluded_paths,omitempty"`
-	TcpPorts         map[uint16]uint16 `json:"tcp_ports,omitempty"`
-	ExcludedTcpPorts []uint16          `json:"excluded_tcp_ports,omitempty"`
-	ForceCreate      bool              `json:"force_create,omitempty"`
-	DisableStart     bool              `json:"disable_start,omitempty"`
-	Debug            bool              `json:"debug,omitempty"`
+	SourceHost       string            `json:"source_host"`
+	TargetHost       string            `json:"target_host"`
+	ContainerName    string            `json:"container_name"`
+	SourceUser       string            `json:"source_user"`
+	TargetUser       string            `json:"target_user"`
+	ExcludePaths     []string          `json:"excluded_paths"`
+	TCPPorts         map[uint16]uint16 `json:"tcp_ports"`
+	ExcludedTCPPorts []uint16          `json:"excluded_tcp_ports"`
+	ForceCreate      bool              `json:"force_create"`
+	DisableStart     bool              `json:"disable_start"`
+	Debug            bool              `json:"debug"`
 }
 
+// buildActorInput translates the data sent by the client into data that the actor can interpret.
+// TODO: this function is not ready yet; it should validate input data and set default values
+func buildActorInput(p *MigrateParams) (string, error) {
+	data := make(map[string]interface{})
+
+	var sc bool
+	if p.DisableStart == true {
+		sc = false
+	} else {
+		sc = true
+	}
+	data["start_container"] = map[string]interface{}{"value": sc}
+	data["container_name"] = map[string]interface{}{"value": p.ContainerName}
+	data["force_create"] = map[string]interface{}{"value": p.ForceCreate}
+	data["source_host"] = map[string]interface{}{"value": p.SourceHost}
+	data["source_user_name"] = map[string]interface{}{"value": p.SourceUser}
+	data["target_host"] = map[string]interface{}{"value": p.TargetHost}
+	data["target_user_name"] = map[string]interface{}{"value": p.TargetUser}
+	data["excluded_paths"] = map[string]interface{}{"value": p.ExcludePaths}
+	data["excluded_tcp_ports"] = map[string]interface{}{"tcp": make(map[string]string)}
+	data["tcp_ports_user_mapping"] = map[string]interface{}{"ports": []string{}}
+	data["use_default_port_map"] = map[string]interface{}{"value": true}
+
+	j, err := json.Marshal(data)
+	if err != nil {
+		return "", err
+	}
+
+	return string(j), nil
+}
+
+// MigrateMachine handles the /migrate-machine endpoint.
 func MigrateMachine(request *http.Request) (interface{}, error) {
-	var (
-		migrateParams MigrateParams
-		data          interface{}
-	)
+	var params MigrateParams
 
-	if err := json.NewDecoder(request.Body).Decode(&migrateParams); err != nil {
+	if err := json.NewDecoder(request.Body).Decode(&params); err != nil {
 		return nil, err
 	}
 
-	// place for executor
-	// Executor.execute // or something
-	output_mock := []byte("{\"foo\": \"bar\"}")
-	// return result to client
-
-	if err := json.Unmarshal(output_mock, &data); err != nil {
+	// Translate data sent by client into data that actor can read
+	actorData, err := buildActorInput(&params)
+	if err != nil {
 		return nil, err
 	}
 
-	return data, nil
+	// Call the actor runner passing data to its stdin
+	c := executor.Command{
+		CmdLine: strings.Split(RUNNER, " "),
+		Stdin:   actorData,
+	}
+
+	// TODO: this blocks until the migration is done; so we might execute this in a worker in the future
+	r := c.Execute()
+
+	log.Println(r.Stderr)
+
+	return r.Stdout, nil
 }

--- a/pkg/api/migrate_machine.go
+++ b/pkg/api/migrate_machine.go
@@ -69,5 +69,7 @@ func MigrateMachine(request *http.Request) (interface{}, error) {
 
 	log.Println(r.Stderr)
 
-	return r.Stdout, nil
+	var out interface{}
+	err = json.Unmarshal([]byte(r.Stdout), &out)
+	return out, err
 }

--- a/pkg/api/migrate_machine.go
+++ b/pkg/api/migrate_machine.go
@@ -10,15 +10,17 @@ import (
 
 // MigrateParams represents the parameters sent by the client
 type MigrateParams struct {
-	StartContainer    bool     `json:"start_container"`
-	ContainerName     string   `json:"container_name"`
-	ForceCreate       bool     `json:"force_create"`
-	SourceHost        string   `json:"source_host"`
-	SourceUser        string   `json:"source_user"`
-	TargetHost        string   `json:"target_host"`
-	TargetUser        string   `json:"target_user"`
-	ExcludePaths      []string `json:"excluded_paths"`
-	UseDefaultPortMap bool     `json:"use_default_port_map"`
+	StartContainer      bool                `json:"start_container"`
+	ContainerName       string              `json:"container_name"`
+	ForceCreate         bool                `json:"force_create"`
+	SourceHost          string              `json:"source_host"`
+	SourceUser          string              `json:"source_user"`
+	TargetHost          string              `json:"target_host"`
+	TargetUser          string              `json:"target_user"`
+	ExcludePaths        []string            `json:"excluded_paths"`
+	UseDefaultPortMap   bool                `json:"use_default_port_map"`
+	TCPPortsUserMapping TCPPortsUserMapping `json:"tcp_ports_user_mapping"`
+	ExcludedTCPPorts    ExcludedTCPPorts    `json:"excluded_tcp_ports"`
 }
 
 // buildActorInput translates the data sent by the client into data that the actor can interpret.
@@ -33,8 +35,8 @@ func buildActorInput(p *MigrateParams) (string, error) {
 		"target_user_name":       ObjValue{p.TargetUser},
 		"excluded_paths":         ObjValue{p.ExcludePaths},
 		"use_default_port_map":   ObjValue{p.UseDefaultPortMap},
-		"excluded_tcp_ports":     ExcludedTCPPorts{TCP: make(map[uint16]uint16)},
-		"tcp_ports_user_mapping": TCPPortsUserMapping{[]string{}},
+		"tcp_ports_user_mapping": p.TCPPortsUserMapping,
+		"excluded_tcp_ports":     p.ExcludedTCPPorts,
 	}
 
 	j, err := json.Marshal(data)

--- a/pkg/api/migrate_machine.go
+++ b/pkg/api/migrate_machine.go
@@ -4,53 +4,38 @@ import (
 	"encoding/json"
 	"log"
 	"net/http"
-	"strings"
 
 	"github.com/leapp-to/leapp-go/pkg/executor"
 )
 
-// RUNNER is an actor execution tool
-// TODO: using a wrapper script for testing only, but runner.py in snactor repo should be refactored into a standalone tool so it can be used by leapp-daemon
-const RUNNER = "/home/fjb/src/snactor/runner_wrapper.sh"
-
 // MigrateParams represents the parameters sent by the client
-// TODO: there are more parameters to add here
 type MigrateParams struct {
-	SourceHost       string            `json:"source_host"`
-	TargetHost       string            `json:"target_host"`
-	ContainerName    string            `json:"container_name"`
-	SourceUser       string            `json:"source_user"`
-	TargetUser       string            `json:"target_user"`
-	ExcludePaths     []string          `json:"excluded_paths"`
-	TCPPorts         map[uint16]uint16 `json:"tcp_ports"`
-	ExcludedTCPPorts []uint16          `json:"excluded_tcp_ports"`
-	ForceCreate      bool              `json:"force_create"`
-	DisableStart     bool              `json:"disable_start"`
-	Debug            bool              `json:"debug"`
+	StartContainer    bool     `json:"start_container"`
+	ContainerName     string   `json:"container_name"`
+	ForceCreate       bool     `json:"force_create"`
+	SourceHost        string   `json:"source_host"`
+	SourceUser        string   `json:"source_user"`
+	TargetHost        string   `json:"target_host"`
+	TargetUser        string   `json:"target_user"`
+	ExcludePaths      []string `json:"excluded_paths"`
+	UseDefaultPortMap bool     `json:"use_default_port_map"`
 }
 
 // buildActorInput translates the data sent by the client into data that the actor can interpret.
-// TODO: this function is not ready yet; it should validate input data and set default values
 func buildActorInput(p *MigrateParams) (string, error) {
-	data := make(map[string]interface{})
-
-	var sc bool
-	if p.DisableStart == true {
-		sc = false
-	} else {
-		sc = true
+	data := map[string]interface{}{
+		"start_container":        ObjValue{p.StartContainer},
+		"container_name":         ObjValue{p.ContainerName},
+		"force_create":           ObjValue{p.ForceCreate},
+		"source_host":            ObjValue{p.SourceHost},
+		"source_user_name":       ObjValue{p.SourceUser},
+		"target_host":            ObjValue{p.TargetHost},
+		"target_user_name":       ObjValue{p.TargetUser},
+		"excluded_paths":         ObjValue{p.ExcludePaths},
+		"use_default_port_map":   ObjValue{p.UseDefaultPortMap},
+		"excluded_tcp_ports":     ExcludedTCPPorts{TCP: make(map[uint16]uint16)},
+		"tcp_ports_user_mapping": TCPPortsUserMapping{[]string{}},
 	}
-	data["start_container"] = map[string]interface{}{"value": sc}
-	data["container_name"] = map[string]interface{}{"value": p.ContainerName}
-	data["force_create"] = map[string]interface{}{"value": p.ForceCreate}
-	data["source_host"] = map[string]interface{}{"value": p.SourceHost}
-	data["source_user_name"] = map[string]interface{}{"value": p.SourceUser}
-	data["target_host"] = map[string]interface{}{"value": p.TargetHost}
-	data["target_user_name"] = map[string]interface{}{"value": p.TargetUser}
-	data["excluded_paths"] = map[string]interface{}{"value": p.ExcludePaths}
-	data["excluded_tcp_ports"] = map[string]interface{}{"tcp": make(map[string]string)}
-	data["tcp_ports_user_mapping"] = map[string]interface{}{"ports": []string{}}
-	data["use_default_port_map"] = map[string]interface{}{"value": true}
 
 	j, err := json.Marshal(data)
 	if err != nil {
@@ -69,16 +54,13 @@ func MigrateMachine(request *http.Request) (interface{}, error) {
 	}
 
 	// Translate data sent by client into data that actor can read
-	actorData, err := buildActorInput(&params)
+	actorInput, err := buildActorInput(&params)
 	if err != nil {
 		return nil, err
 	}
 
 	// Call the actor runner passing data to its stdin
-	c := executor.Command{
-		CmdLine: strings.Split(RUNNER, " "),
-		Stdin:   actorData,
-	}
+	c := executor.New("migrate-machine", actorInput)
 
 	// TODO: this blocks until the migration is done; so we might execute this in a worker in the future
 	r := c.Execute()

--- a/pkg/api/values.go
+++ b/pkg/api/values.go
@@ -1,16 +1,40 @@
 package api
 
+import "encoding/json"
+
 type ObjValue struct {
 	Value interface{} `json:"value"`
 }
 
-// TODO: TCPPortsUserMapping and ExcludedTCPPorts types are here just to satisfy the actor's input validation until we refactor them (in there respective actors)
+type PortForwarding struct {
+	Protocol    string `json:"protocol"`
+	ExposedPort uint16 `json:"exposed_port"`
+	Port        uint16 `json:"port"`
+}
+
+type PortForwardingSlice []PortForwarding
+
+func (forwarding PortForwardingSlice) MarshalJSON() ([]byte, error) {
+	if forwarding == nil {
+		return []byte("[]"), nil
+	}
+	return json.Marshal([]PortForwarding(forwarding))
+}
 
 type TCPPortsUserMapping struct {
-	Ports []string `json:"ports"`
+	Ports PortForwardingSlice `json:"ports"`
+}
+
+type PortMapping map[uint16]map[string]string
+
+func (mapping PortMapping) MarshalJSON() ([]byte, error) {
+	if mapping == nil {
+		return []byte("{}"), nil
+	}
+	return json.Marshal(map[uint16]map[string]string(mapping))
 }
 
 type ExcludedTCPPorts struct {
-	TCP map[uint16]uint16 `json:"tcp"`
-	UDP map[uint16]uint16 `json:"udp,omitempty"`
+	TCP PortMapping `json:"tcp"`
+	UDP PortMapping `json:"udp"`
 }

--- a/pkg/api/values.go
+++ b/pkg/api/values.go
@@ -1,0 +1,16 @@
+package api
+
+type ObjValue struct {
+	Value interface{} `json:"value"`
+}
+
+// TODO: TCPPortsUserMapping and ExcludedTCPPorts types are here just to satisfy the actor's input validation until we refactor them (in there respective actors)
+
+type TCPPortsUserMapping struct {
+	Ports []string `json:"ports"`
+}
+
+type ExcludedTCPPorts struct {
+	TCP map[uint16]uint16 `json:"tcp"`
+	UDP map[uint16]uint16 `json:"udp,omitempty"`
+}

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -1,4 +1,4 @@
-// Package executor provides an abstration for executing commands in the OS.
+// Package executor provides an abstration for executing actors using an external tool.
 package executor
 
 import (
@@ -7,6 +7,10 @@ import (
 	"strings"
 	"syscall"
 )
+
+// actorRunner is an actor execution tool
+// TODO: using a wrapper script for testing only, but runner.py in snactor repo should be refactored into a standalone tool so it can be used by leapp-daemon
+const actorRunner = "/usr/local/bin/actor_runner"
 
 // Result represents the outcome of a command execution.
 type Result struct {
@@ -17,7 +21,7 @@ type Result struct {
 
 // Command represents the command to be executed along its stdin.
 type Command struct {
-	CmdLine []string
+	cmdLine []string
 	Stdin   string
 }
 
@@ -26,7 +30,7 @@ type Command struct {
 func (c *Command) Execute() *Result {
 	var stderr, stdout bytes.Buffer
 
-	cmd := exec.Command(c.CmdLine[0], c.CmdLine[1:]...)
+	cmd := exec.Command(c.cmdLine[0], c.cmdLine[1:]...)
 
 	cmd.Stdin = strings.NewReader(c.Stdin)
 	cmd.Stdout = &stdout
@@ -58,4 +62,14 @@ func runWithExitCode(cmd *exec.Cmd) int {
 	}
 
 	return exitCode
+}
+
+// New initializes a new Command that works with actorRunner
+func New(actorName, stdin string) *Command {
+	cl := append(strings.Split(actorRunner, " "), actorName)
+	c := &Command{cmdLine: cl,
+		Stdin: stdin,
+	}
+
+	return c
 }

--- a/pkg/executor/executor_test.go
+++ b/pkg/executor/executor_test.go
@@ -21,7 +21,7 @@ func TestSuccessExec(t *testing.T) {
 	for _, td := range testData {
 
 		c := Command{
-			CmdLine: td.Cmd,
+			cmdLine: td.Cmd,
 			Stdin:   td.Stdin,
 		}
 
@@ -52,7 +52,7 @@ func TestFailExec(t *testing.T) {
 	for _, td := range testData {
 
 		c := Command{
-			CmdLine: td.Cmd,
+			cmdLine: td.Cmd,
 			Stdin:   td.Stdin,
 		}
 


### PR DESCRIPTION
This PR integrates the `/migrate-machine` endpoint with the `executor`. As a result, I was able to perform a macrocontainer migration using `leappctl`.

I left some `TODO`s in the code, but I think this PR proves to point.

Here's how the migration was done:

1. Started `leapp-daemon`:

```su -c "SSH_AUTH_SOCK=$SSH_AUTH_SOCK go run cmd/leapp-daemon/main.go -timeout 100"```

2. Executed `leappctl`:

```leappctl migrate-machine -s 192.168.121.209 -u vagrant -t 127.0.0.1 -U vagrant -n centos6```

Some hightlights:

* Executed `leapp-daemon` as root because the actor-runner tool require root privileges. Of course this won't be a requirement.
* `/usr/local/bin/actor_runner` is a simple script that wraps `tools/runner.py` (from `snactor` lib) to avoid passing in its arguments (e.g., `--actors-dir`). It should be replaced by a standalone tool once we have it.