### PR TITLE
Port inspect output

### DIFF
--- a/pkg/api/port_inspect.go
+++ b/pkg/api/port_inspect.go
@@ -25,6 +25,7 @@ func portInspectHandler(request *http.Request) (*executor.Command, error) {
 		"scan_options": map[string]interface{}{
 			"shallow_scan": params.ShallowScan,
 			"port_range":   params.PortRange,
+			"force_nmap":   !params.ShallowScan,
 		},
 	}
 

--- a/pkg/api/port_inspect.go
+++ b/pkg/api/port_inspect.go
@@ -34,6 +34,6 @@ func portInspectHandler(request *http.Request) (*executor.Command, error) {
 		return nil, err
 	}
 
-	c := executor.New("port-inspect", string(actorInput))
+	c := executor.New("portscan", string(actorInput))
 	return c, nil
 }


### PR DESCRIPTION
port-inspect group is not required in the daemon therefore it is replaced by pure portscan.