### PR TITLE
Add script to update documentation on Leapp GH pages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,10 @@ before_install:
 
 script:
   - make test-all
+
+after_success:
+  - bash update_documentation.sh
+
+env:
+  global:
+    secure: "CvzpBleQdo0UMRsbKUW1/PsljgJuoH3lq4e3WeRcjBpnioYIIhWl6GR3ETNEhhzqSWIU7qauUJinQfbcU7ubGBLaMEoqApB3oNz7jzEMRynX2DrZmAGNPWmDTy0Z5wfyIzCdhIJrLNrc761YPh0xkj2NSAyfelDb6xPQFbTfmN6j/cowhnWoFljZTcg+FfVnNKy6q7DPJyg0D87ghByDEHVHf/TH8Y8JwTwqMMK/Fg8GZM/VxRvkIfRfjY1HKVzxcYTd8pAYJi7CR/niVd57bocbBUjyTZRtNANkcGls+jAmxDFiHH+wR54naUxUACYmneEPfhkvJTzLU971472jm4j59DUUGaPflBah45eUXlo4YRnRSlQoKMA5GcZlfVOe608OibAvL8AWfVURoKhEZum6NI805ljrr8lyD1jRgu/HhTztF8FjER3eMoPAbpklO+A2aOe+MocGXiN3UbEkzamZhwTJ2emUH4wkPJAx0DXFQYjgzQEKaM1fvoif3RUJJwZSI/CLJBMV+jojRE+6AyaZTEsksl1p+7LEwKQ+WBCivLyWqktxD4J+yo8TW51n9WcKLiFiXer99TrkMjnOR57+EyVIGbK+SNZs/tayyfl0SE0s/Q7NBziP8xR4GgZVLgAqYC+pg/y8KTuNft8K+LRF+2sGIHlspC+mbn3vPsI="

--- a/update_documentation.sh
+++ b/update_documentation.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+request_update_doc() {
+	git clone "https://$GH_TOKEN@github.com/leapp-to/leapp-to.github.io.git"
+	cd leapp-to.github.io
+	git config user.name "Travis-CI"
+	cp ../index.html.md shins/source/index.html.md
+	cd shins
+	node $NVM_BIN/shins --minify
+	git add -A
+	git commit -m "rebuild pages at $commit"
+	git push origin HEAD:master
+}
+
+install_npm_deps() {
+	npm install -g widdershins shins
+}
+
+convert_documentation() {
+	node $NVM_BIN/widdershins -y ./docs/api/api.yaml -o index.html.md
+}
+
+#checks if it's merge action
+if [[ $TRAVIS_PULL_REQUEST == "false" && $TRAVIS_BRANCH == "master" ]]; then
+	echo "Update documentation has been triggered"
+	changed_files=`git diff --name-only HEAD^`
+	commit=$(git rev-parse --short HEAD)
+	# checks if merged PR contains any changes in api.yaml
+	if [[ $changed_files =~ .*api.yaml ]]; then
+		install_npm_deps
+		convert_documentation
+		request_update_doc
+		exit 0
+	else
+		exit 0
+	fi
+else
+	echo "Update documentation has not been triggered"
+fi


### PR DESCRIPTION
The update is triggered only on 'push to master branch' event,
when docs/api/api.yaml has been changed

Related PR (that's adding Shins) in GH page repository: https://github.com/leapp-to/leapp-to.github.io/pull/7